### PR TITLE
refactor(advanced list): replaced switch + any views with group + if

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "af667b368a10512da79605b61698d53c11d24cbf",
           "version": "0.1.1"
         }
+      },
+      {
+        "package": "ViewInspector",
+        "repositoryURL": "https://github.com/nalexn/ViewInspector.git",
+        "state": {
+          "branch": null,
+          "revision": "ec943ed718cd293b95f17a2b81e8917d6ed70752",
+          "version": "0.3.8"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
             targets: ["AdvancedList"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/crelies/ListPagination", from: "0.1.0")
+        .package(url: "https://github.com/crelies/ListPagination", from: "0.1.0"),
+        .package(url: "https://github.com/nalexn/ViewInspector.git", from: "0.3.8")
     ],
     targets: [
         .target(
@@ -24,6 +25,6 @@ let package = Package(
             dependencies: ["ListPagination"]),
         .testTarget(
             name: "AdvancedListTests",
-            dependencies: ["AdvancedList"]),
+            dependencies: ["AdvancedList", "ViewInspector"]),
     ]
 )

--- a/Sources/AdvancedList/private/Models/AnyDynamicViewContent.swift
+++ b/Sources/AdvancedList/private/Models/AnyDynamicViewContent.swift
@@ -7,16 +7,14 @@
 
 import SwiftUI
 
-extension AdvancedList {
-    struct AnyDynamicViewContent: DynamicViewContent {
-        private let view: AnyView
+struct AnyDynamicViewContent: DynamicViewContent {
+    private let view: AnyView
 
-        private(set) var data: AnyCollection<Any>
-        var body: some View { view }
+    private(set) var data: AnyCollection<Any>
+    var body: some View { view }
 
-        init<View: DynamicViewContent>(_ view: View) {
-            self.view = AnyView(view)
-            self.data = AnyCollection(view.data.map { $0 as Any })
-        }
+    init<View: DynamicViewContent>(_ view: View) {
+        self.view = AnyView(view)
+        self.data = AnyCollection(view.data.map { $0 as Any })
     }
 }

--- a/Sources/AdvancedList/public/Models/ListState.swift
+++ b/Sources/AdvancedList/public/Models/ListState.swift
@@ -14,6 +14,15 @@ public enum ListState {
     case loading
 }
 
+extension ListState {
+    var error: Error? {
+        guard case let ListState.error(error) = self else {
+            return nil
+        }
+        return error
+    }
+}
+
 extension ListState: Equatable {
     public static func ==(lhs: ListState, rhs: ListState) -> Bool {
         switch (lhs, rhs) {

--- a/Sources/AdvancedList/public/Views/AdvancedList.swift
+++ b/Sources/AdvancedList/public/Views/AdvancedList.swift
@@ -40,12 +40,9 @@ public struct AdvancedList<Data: RandomAccessCollection, Content: View, EmptySta
 
 extension AdvancedList {
     public var body: some View {
-        switch listState.wrappedValue {
-        case .error(let error):
-            return AnyView(errorStateView(error))
-        case .items:
-            if !data.isEmpty {
-                return AnyView(
+        Group {
+            if listState.wrappedValue == .items {
+                if !data.isEmpty {
                     VStack {
                         getListView()
 
@@ -53,12 +50,16 @@ extension AdvancedList {
                             getPaginationStateView()
                         }
                     }
-                )
+                } else {
+                    emptyStateView()
+                }
+            } else if listState.wrappedValue == .loading {
+                loadingStateView()
             } else {
-                return AnyView(emptyStateView())
+                listState.wrappedValue.error.map {
+                    errorStateView($0)
+                }
             }
-        case .loading:
-            return AnyView(loadingStateView())
         }
     }
 }

--- a/Tests/AdvancedListTests/AdvancedListTests.swift
+++ b/Tests/AdvancedListTests/AdvancedListTests.swift
@@ -10,75 +10,107 @@ import SwiftUI
 import XCTest
 
 final class AdvancedListTests: XCTestCase {
-    @State private var listState: ListState = .items
-
-    private let emptyStateView = Text("Empty")
-    private let errorStateView = Text("Error")
-    private let loadingStateView = Text("Loading ...")
-
-    override func setUp() {
-        listState = .items
-    }
+    private let emptyStateString = "Empty"
+    private lazy var emptyStateView = Text(emptyStateString)
+    private let errorStateString = "Error"
+    private lazy var errorStateView = Text(errorStateString)
+    private let loadingStateString = "Loading ..."
+    private lazy var loadingStateView = Text(loadingStateString)
 
     func testEmptyStateView() {
+        let emptyListState: Binding<ListState> = .constant(.items)
+
         let items: [String] = []
 
         let view = AdvancedList(items, content: { item in Text(item) },
-                                listState: $listState,
+                                listState: emptyListState,
                                 emptyStateView: { self.emptyStateView },
                                 errorStateView: { _ in self.errorStateView },
                                 loadingStateView: { self.loadingStateView },
                                 pagination: .noPagination)
 
-        let body = view.body as? AnyView
-        XCTAssertNotNil(body)
+        do {
+            let inspectableView = try view.body.inspect()
+            let textString = try inspectableView.group().first?.text().string()
+            XCTAssertEqual(textString, emptyStateString)
+        } catch {
+            XCTFail("\(error)")
+        }
     }
 
     func testNotEmptyStateView() {
-        let items: [String] = ["MockItem1", "MockItem2"]
+        let itemsListState: Binding<ListState> = .constant(.items)
+
+        let mockItem1 = "MockItem1"
+        let mockItem2 = "MockItem2"
+        let items: [String] = [mockItem1, mockItem2]
 
         let view = AdvancedList(items, content: { item in Text(item) },
-                                listState: $listState,
+                                listState: itemsListState,
                                 emptyStateView: { self.emptyStateView },
                                 errorStateView: { _ in self.errorStateView },
                                 loadingStateView: { self.loadingStateView },
                                 pagination: .noPagination)
 
-        let body = view.body as? AnyView
-        XCTAssertNotNil(body)
+        do {
+            let inspectableView = try view.body.inspect()
+            let group = try inspectableView.group().first
+            let vStack = try group?.vStack()
+            let list = try vStack?.list(0)
+            let anyDynamicViewContent = try list?.first?.view(AnyDynamicViewContent.self)
+            let forEach = try anyDynamicViewContent?.anyView().forEach()
+
+            let firstElement = forEach?.first
+            XCTAssertEqual(try firstElement?.text().string(), mockItem1)
+
+            let secondElement = forEach?[1]
+            XCTAssertEqual(try secondElement?.text().string(), mockItem2)
+        } catch {
+            XCTFail("\(error)")
+        }
     }
 
     func testLoadingStateView() {
-        listState = .loading
+        let loadingListState: Binding<ListState> = .constant(.loading)
 
         let items: [String] = []
 
         let view = AdvancedList(items, content: { item in Text(item) },
-                                listState: $listState,
+                                listState: loadingListState,
                                 emptyStateView: { self.emptyStateView },
                                 errorStateView: { _ in self.errorStateView },
                                 loadingStateView: { self.loadingStateView },
                                 pagination: .noPagination)
 
-        let body = view.body as? AnyView
-        XCTAssertNotNil(body)
+        do {
+            let inspectableView = try view.body.inspect()
+            let textString = try inspectableView.group().first?.text().string()
+            XCTAssertEqual(textString, loadingStateString)
+        } catch {
+            XCTFail("\(error)")
+        }
     }
 
     func testErrorStateView() {
         let error = NSError(domain: "MockDomain", code: 1, userInfo: nil)
-        listState = .error(error)
+        let errorListState: Binding<ListState> = .constant(.error(error))
 
         let items: [String] = []
 
         let view = AdvancedList(items, content: { item in Text(item) },
-                                listState: $listState,
+                                listState: errorListState,
                                 emptyStateView: { self.emptyStateView },
                                 errorStateView: { _ in self.errorStateView },
                                 loadingStateView: { self.loadingStateView },
                                 pagination: .noPagination)
 
-        let body = view.body as? AnyView
-        XCTAssertNotNil(body)
+        do {
+            let inspectableView = try view.body.inspect()
+            let textString = try inspectableView.group().first?.text().string()
+            XCTAssertEqual(textString, errorStateString)
+        } catch {
+            XCTFail("\(error)")
+        }
     }
 
     static var allTests = [

--- a/Tests/AdvancedListTests/Extensions/AdvancedList+Inspectable.swift
+++ b/Tests/AdvancedListTests/Extensions/AdvancedList+Inspectable.swift
@@ -1,0 +1,11 @@
+//
+//  AdvancedList+Inspectable.swift
+//  AdvancedListTests
+//
+//  Created by Christian Elies on 22.02.20.
+//
+
+@testable import AdvancedList
+import ViewInspector
+
+extension AdvancedList: Inspectable {}

--- a/Tests/AdvancedListTests/Extensions/AnyDynamicViewContent+Inspectable.swift
+++ b/Tests/AdvancedListTests/Extensions/AnyDynamicViewContent+Inspectable.swift
@@ -1,0 +1,11 @@
+//
+//  AnyDynamicViewContent+Inspectable.swift
+//  AdvancedListTests
+//
+//  Created by Christian Elies on 22.02.20.
+//
+
+@testable import AdvancedList
+import ViewInspector
+
+extension AnyDynamicViewContent: Inspectable {}


### PR DESCRIPTION
Got rid off `AnyView`s and the `switch`. Replaced them with the use of a `Group`, `if` statements and a `map`.